### PR TITLE
Change the triggers of the `library-check` CI workflow.

### DIFF
--- a/.github/workflows/library-check.yaml
+++ b/.github/workflows/library-check.yaml
@@ -2,12 +2,16 @@
 #
 # This workflow is responsible for running checks on pushed commits.
 #
-# The workflow is triggered on each push to a branch.
+# The workflow is triggered on pull requests and pushes to the main branch.
+# Pull requests are checked on a merge branch, not on the pull request branch.
 
 name: library-check
 
 on:
-  push: {}
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   # Run the `spec` binary for this library.


### PR DESCRIPTION
Pull requests are now checked on a merge branch, not on the pull request branch.
This ensures they are testing the combined code, rather than just testing
the branch associated with the pull request in isolation.